### PR TITLE
Improve test code and fix bug with BigVector push requests

### DIFF
--- a/src/main/scala/glint/models/client/async/AsyncBigVector.scala
+++ b/src/main/scala/glint/models/client/async/AsyncBigVector.scala
@@ -108,7 +108,7 @@ abstract class AsyncBigVector[@specialized V: Semiring : ClassTag, R: ClassTag, 
     // Send push requests
     val pushes = mapPartitions(indexedKeys) {
       case (partition, indices) =>
-        (partition ? toPushMessage(indices.map(keys).toArray, indices.map(values).toArray)).mapTo[Boolean]
+        (partition ? toPushMessage(indices.map(indexedKeys).toArray, indices.map(values).toArray)).mapTo[Boolean]
     }
 
     // Combine and aggregate futures

--- a/src/test/scala/glint/BigMatrixSpec.scala
+++ b/src/test/scala/glint/BigMatrixSpec.scala
@@ -68,7 +68,7 @@ class BigMatrixSpec extends FlatSpec with SystemTest with Matchers {
   }
 
   it should "store Long values" in withMaster { _ =>
-    withServer { _ =>
+    withServers(3) { _ =>
       withClient { client =>
         val model = whenReady(client.matrix[Long](23, 10)) {
           identity
@@ -87,26 +87,24 @@ class BigMatrixSpec extends FlatSpec with SystemTest with Matchers {
   }
 
   it should "aggregate values through addition" in withMaster { _ =>
-    withServer { _ =>
-      withServer { _ =>
-        withClient { client =>
-          val model = whenReady(client.matrix[Int](9, 100)) {
-            identity
-          }
-          val result1 = whenReady(model.push(Array(0L, 2L, 5L, 8L), Array(0, 10, 99, 80), Array(100, 100, 20, 30))) {
-            identity
-          }
-          val result2 = whenReady(model.push(Array(0L, 2L, 5L, 8L), Array(0, 10, 99, 80), Array(1, -1, 2, 3))) {
-            identity
-          }
-          assert(result1)
-          assert(result2)
-          val future = model.pull(Array(0L, 2L, 5L, 8L), Array(0, 10, 99, 80))
-          val value = whenReady(future) {
-            identity
-          }
-          value should equal(Array(101, 99, 22, 33))
+    withServers(2) { _ =>
+      withClient { client =>
+        val model = whenReady(client.matrix[Int](9, 100)) {
+          identity
         }
+        val result1 = whenReady(model.push(Array(0L, 2L, 5L, 8L), Array(0, 10, 99, 80), Array(100, 100, 20, 30))) {
+          identity
+        }
+        val result2 = whenReady(model.push(Array(0L, 2L, 5L, 8L), Array(0, 10, 99, 80), Array(1, -1, 2, 3))) {
+          identity
+        }
+        assert(result1)
+        assert(result2)
+        val future = model.pull(Array(0L, 2L, 5L, 8L), Array(0, 10, 99, 80))
+        val value = whenReady(future) {
+          identity
+        }
+        value should equal(Array(101, 99, 22, 33))
       }
     }
   }
@@ -114,28 +112,26 @@ class BigMatrixSpec extends FlatSpec with SystemTest with Matchers {
   it should "deserialize without an ActorSystem in scope" in {
     var ab: Array[Byte] = Array.empty[Byte]
     withMaster { _ =>
-      withServer { _ =>
-        withServer { _ =>
-          withClient { client =>
-            val model = whenReady(client.matrix[Int](9, 10)) {
-              identity
-            }
-            val bos = new ByteArrayOutputStream
-            val out = new ObjectOutputStream(bos)
-            out.writeObject(model)
-            out.close()
-            ab = bos.toByteArray
-
-            whenReady(model.push(Array(0L, 7L), Array(1, 2), Array(12, 42))) { identity }
-
-            val bis = new ByteArrayInputStream(ab)
-            val in = new ObjectInputStream(bis)
-            val matrix = in.readObject().asInstanceOf[BigMatrix[Int]]
-            val result = whenReady(matrix.pull(Array(0L, 7L), Array(1, 2))) {
-              identity
-            }
-            result should equal(Array(12, 42))
+      withServers(2) { _ =>
+        withClient { client =>
+          val model = whenReady(client.matrix[Int](9, 10)) {
+            identity
           }
+          val bos = new ByteArrayOutputStream
+          val out = new ObjectOutputStream(bos)
+          out.writeObject(model)
+          out.close()
+          ab = bos.toByteArray
+
+          whenReady(model.push(Array(0L, 7L), Array(1, 2), Array(12, 42))) { identity }
+
+          val bis = new ByteArrayInputStream(ab)
+          val in = new ObjectInputStream(bis)
+          val matrix = in.readObject().asInstanceOf[BigMatrix[Int]]
+          val result = whenReady(matrix.pull(Array(0L, 7L), Array(1, 2))) {
+            identity
+          }
+          result should equal(Array(12, 42))
         }
       }
     }

--- a/src/test/scala/glint/BigVectorSpec.scala
+++ b/src/test/scala/glint/BigVectorSpec.scala
@@ -68,7 +68,7 @@ class BigVectorSpec extends FlatSpec with SystemTest with Matchers {
   }
 
   it should "store Long values" in withMaster { _ =>
-    withServer { _ =>
+    withServers(2) { _ =>
       withClient { client =>
         val model = whenReady(client.vector[Long](9)) {
           identity
@@ -87,7 +87,7 @@ class BigVectorSpec extends FlatSpec with SystemTest with Matchers {
   }
 
   it should "aggregate values through addition" in withMaster { _ =>
-    withServer { _ =>
+    withServers(3) { _ =>
       withClient { client =>
         val model = whenReady(client.vector[Int](100)) {
           identity
@@ -112,7 +112,7 @@ class BigVectorSpec extends FlatSpec with SystemTest with Matchers {
   it should "deserialize without an ActorSystem in scope" in {
     var ab: Array[Byte] = Array.empty[Byte]
     withMaster { _ =>
-      withServer { _ =>
+      withServers(3) { _ =>
         withClient { client =>
           val model = whenReady(client.vector[Int](10)) {
             identity

--- a/src/test/scala/glint/ClientSpec.scala
+++ b/src/test/scala/glint/ClientSpec.scala
@@ -47,35 +47,29 @@ class ClientSpec extends FlatSpec with SystemTest {
   }
 
   it should "be able to create a BigMatrix with less rows than servers" in withMaster { _ =>
-    withServer { server1 =>
-      withServer { server2 =>
-        withServer { server3 =>
-          withClient { client =>
-            val model = whenReady(client.matrix[Long](2, 10)) {
-              identity
-            }
-            assert(model.isInstanceOf[BigMatrix[Long]])
-          }
+    withServers(3) { case _ =>
+      withClient { client =>
+        val model = whenReady(client.matrix[Long](2, 10)) {
+          identity
         }
+        assert(model.isInstanceOf[BigMatrix[Long]])
       }
     }
   }
 
   it should "be able to create a BigMatrix with more rows than servers" in withMaster { _ =>
-    withServer { server1 =>
-      withServer { server2 =>
-        withClient { client =>
-          val model = whenReady(client.matrix[Long](49, 7)) {
-            identity
-          }
-          assert(model.isInstanceOf[BigMatrix[Long]])
+    withServers(2) { _ =>
+      withClient { client =>
+        val model = whenReady(client.matrix[Long](49, 7)) {
+          identity
         }
+        assert(model.isInstanceOf[BigMatrix[Long]])
       }
     }
   }
 
   it should "be able to create a BigMatrix[Int]" in withMaster { _ =>
-    withServer { server1 =>
+    withServer { server =>
       withClient { client =>
         val model = whenReady(client.matrix[Int](49, 7)) {
           identity
@@ -86,7 +80,7 @@ class ClientSpec extends FlatSpec with SystemTest {
   }
 
   it should "be able to create a BigMatrix[Long]" in withMaster { _ =>
-    withServer { server1 =>
+    withServer { server =>
       withClient { client =>
         val model = whenReady(client.matrix[Long](49, 7)) {
           identity
@@ -97,7 +91,7 @@ class ClientSpec extends FlatSpec with SystemTest {
   }
 
   it should "be able to create a BigMatrix[Float]" in withMaster { _ =>
-    withServer { server1 =>
+    withServer { server =>
       withClient { client =>
         val model = whenReady(client.matrix[Float](49, 7)) {
           identity
@@ -108,7 +102,7 @@ class ClientSpec extends FlatSpec with SystemTest {
   }
 
   it should "be able to create a BigMatrix[Double]" in withMaster { _ =>
-    withServer { server1 =>
+    withServer { server =>
       withClient { client =>
         val model = whenReady(client.matrix[Double](49, 7)) {
           identity
@@ -119,7 +113,7 @@ class ClientSpec extends FlatSpec with SystemTest {
   }
 
   it should "be able to create a BigVector[Int]" in withMaster { _ =>
-    withServer { server1 =>
+    withServer { server =>
       withClient { client =>
         val model = whenReady(client.vector[Int](49)) {
           identity
@@ -130,7 +124,7 @@ class ClientSpec extends FlatSpec with SystemTest {
   }
 
   it should "be able to create a BigVector[Long]" in withMaster { _ =>
-    withServer { server1 =>
+    withServer { server =>
       withClient { client =>
         val model = whenReady(client.vector[Long](490)) {
           identity
@@ -141,7 +135,7 @@ class ClientSpec extends FlatSpec with SystemTest {
   }
 
   it should "be able to create a BigVector[Float]" in withMaster { _ =>
-    withServer { server1 =>
+    withServer { server =>
       withClient { client =>
         val model = whenReady(client.vector[Float](1)) {
           identity
@@ -152,7 +146,7 @@ class ClientSpec extends FlatSpec with SystemTest {
   }
 
   it should "be able to create a BigVector[Double]" in withMaster { _ =>
-    withServer { server1 =>
+    withServer { server =>
       withClient { client =>
         val model = whenReady(client.vector[Double](10000)) {
           identity


### PR DESCRIPTION
This pull request fixes #21 and improves the test code by providing a `withServers(n) { ... }` method, removing the necessity of chaining multiple `withServer { _ => withServer { _ => .... } }` together.