### PR TITLE
Add granular model

### DIFF
--- a/src/main/scala/glint/models/client/aggregate/AggregatedBigMatrix.scala
+++ b/src/main/scala/glint/models/client/aggregate/AggregatedBigMatrix.scala
@@ -85,6 +85,9 @@ class AggregatedBigMatrix[V: ClassTag](underlying: BigMatrix[V],
     * @return A future indicating the success or failure of pushing the values to the parameter servers
     */
   def flush()(implicit ec: ExecutionContext, timeout: Timeout): Future[Boolean] = {
+    if (map.isEmpty) {
+      Future { true }
+    }
     val rows = new Array[Long](map.size)
     val cols = new Array[Int](map.size)
     val values = new Array[V](map.size)

--- a/src/main/scala/glint/models/client/granular/GranularBigMatrix.scala
+++ b/src/main/scala/glint/models/client/granular/GranularBigMatrix.scala
@@ -1,0 +1,102 @@
+package glint.models.client.granular
+
+import akka.util.Timeout
+import breeze.linalg.Vector
+import glint.models.client.BigMatrix
+
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.{Future, ExecutionContext}
+import scala.reflect.ClassTag
+
+/**
+  * A BigMatrix whose messages (even for large pulls/pushes) are granular and limited to a specific maximum message
+  * size. This helps resolve timeout exceptions and heartbeat failures in akka at the cost of additional message
+  * overhead.
+  *
+  * @param underlying The underlying big matrix
+  * @param cols The number of columns in the big matrix
+  * @param maximumMessageSize The maximum message size
+  * @tparam V The type of values to store
+  */
+class GranularBigMatrix[V: ClassTag](underlying: BigMatrix[V],
+                                     cols: Int,
+                                     maximumMessageSize: Int) extends BigMatrix[V] {
+
+  /**
+    * Pulls a set of rows
+    *
+    * @param rows The indices of the rows
+    * @return A future containing the vectors representing the rows
+    */
+  override def pull(rows: Array[Long])(implicit timeout: Timeout, ec: ExecutionContext): Future[Array[Vector[V]]] = {
+    var i = 0
+    val maxIncrement = Math.max(1, maximumMessageSize / cols)
+    val ab = new ArrayBuffer[Future[Array[Vector[V]]]](rows.length / maxIncrement)
+    while (i < rows.length) {
+      val end = Math.min(rows.length, i + maxIncrement)
+      val future = underlying.pull(rows.slice(i, end))
+      ab.append(future)
+      i += maxIncrement
+    }
+    Future.sequence(ab.toIterator).map {
+      case arrayOfValues =>
+        val finalValues = new ArrayBuffer[Vector[V]](rows.length)
+        arrayOfValues.foreach(x => finalValues.appendAll(x))
+        finalValues.toArray
+    }
+  }
+
+  /**
+    * Destroys the big matrix and its resources on the parameter server
+    *
+    * @return A future whether the matrix was successfully destroyed
+    */
+  override def destroy()(implicit timeout: Timeout, ec: ExecutionContext): Future[Boolean] = underlying.destroy()
+
+  /**
+    * Pushes a set of values
+    *
+    * @param rows The indices of the rows
+    * @param cols The indices of the columns
+    * @param values The values to update
+    * @return A future containing either the success or failure of the operation
+    */
+  override def push(rows: Array[Long],
+                    cols: Array[Int],
+                    values: Array[V])(implicit timeout: Timeout, ec: ExecutionContext): Future[Boolean] = {
+    var i = 0
+    val ab = new ArrayBuffer[Future[Boolean]](rows.length / maximumMessageSize)
+    while (i < rows.length) {
+      val end = Math.min(rows.length, i + maximumMessageSize)
+      val future = underlying.push(rows.slice(i, end), cols.slice(i, end), values.slice(i, end))
+      ab.append(future)
+      i += maximumMessageSize
+    }
+    Future.sequence(ab.toIterator).transform(x => x.forall(y => y), err => err)
+  }
+
+  /**
+    * Pulls a set of elements
+    *
+    * @param rows The indices of the rows
+    * @param cols The corresponding indices of the columns
+    * @return A future containing the values of the elements at given rows, columns
+    */
+  override def pull(rows: Array[Long],
+                    cols: Array[Int])(implicit timeout: Timeout, ec: ExecutionContext): Future[Array[V]] = {
+    var i = 0
+    val ab = new ArrayBuffer[Future[Array[V]]](rows.length / maximumMessageSize)
+    while (i < rows.length) {
+      val end = Math.min(rows.length, i + maximumMessageSize)
+      val future = underlying.pull(rows.slice(i, end), cols.slice(i, end))
+      ab.append(future)
+      i += maximumMessageSize
+    }
+    Future.sequence(ab.toIterator).map {
+      case arrayOfValues =>
+        val finalValues = new ArrayBuffer[V](rows.length)
+        arrayOfValues.foreach(x => finalValues.appendAll(x))
+        finalValues.toArray
+    }
+  }
+}

--- a/src/test/scala/glint/GranularBigMatrixSpec.scala
+++ b/src/test/scala/glint/GranularBigMatrixSpec.scala
@@ -1,0 +1,39 @@
+package glint
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, ObjectInputStream, ObjectOutputStream}
+
+import glint.models.client.BigMatrix
+import glint.models.client.aggregate.AggregatedBigMatrix
+import glint.models.client.granular.GranularBigMatrix
+import org.scalatest.{FlatSpec, Matchers}
+
+/**
+  * GranularBigMatrix test specification
+  */
+class GranularBigMatrixSpec extends FlatSpec with SystemTest with Matchers {
+
+  "A GranularBigMatrix" should "handle large push/pull requests" in withMaster { _ =>
+    withServers(2) { _ =>
+      withClient { client =>
+        val model = whenReady(client.matrix[Double](1000, 1000)) { identity }
+        val granularModel = new GranularBigMatrix[Double](model, 1000, 200)
+        val rows = new Array[Long](1000000)
+        val cols = new Array[Int](1000000)
+        val values = new Array[Double](1000000)
+        var i = 0
+        while (i < rows.length) {
+          rows(i) = i % 1000
+          cols(i) = i / 1000
+          values(i) = i * 3.14
+          i += 1
+        }
+
+        whenReady(granularModel.push(rows, cols, values)) { identity }
+        val result = whenReady(granularModel.pull(rows, cols)) { identity }
+
+        result shouldEqual values
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Added a GranularBigMatrix model that allows arbitrarily large push/pull requests to happen by manually splitting them up into multiple smaller messages and then glueing the result back together. The user can manually set a maximum message size.