### PR TITLE
Add option to use multiple models per parameter server

### DIFF
--- a/src/main/scala/glint/models/client/async/AsyncBigMatrix.scala
+++ b/src/main/scala/glint/models/client/async/AsyncBigMatrix.scala
@@ -200,6 +200,11 @@ abstract class AsyncBigMatrix[@specialized V: Semiring : ClassTag, R: ClassTag, 
   }
 
   /**
+    * @return The number of partitions this big matrix's data is spread across
+    */
+  def nrOfPartitions: Int = { partitioner.partitions.length }
+
+  /**
     * Deserializes this instance. This starts an ActorSystem with appropriate configuration before attempting to
     * deserialize ActorRefs
     *

--- a/src/main/scala/glint/models/client/async/AsyncBigVector.scala
+++ b/src/main/scala/glint/models/client/async/AsyncBigVector.scala
@@ -132,6 +132,11 @@ abstract class AsyncBigVector[@specialized V: Semiring : ClassTag, R: ClassTag, 
   }
 
   /**
+    * @return The number of partitions this big vector's data is spread across
+    */
+  def nrOfPartitions: Int = { partitioner.partitions.length }
+
+  /**
     * Destroys the matrix on the parameter servers
     *
     * @return A future whether the matrix was successfully destroyed


### PR DESCRIPTION
Added an option to the client to manually set the number of models to spawn on a parameter server. This allows for more parallelism because we will have multiple actors (and thus concurrent threads) per parameter server. The default setting is `1` which is the same behavior as before.

Example usage:

    // Construct vector with 10000 keys and 4 models per parameter server (= 4 threads)
    client.vector[Long](10000, 4)
    
    // Construct matrix with 1000 rows, 1000 cols and 4 models per parameter server
    client.matrix[Long](1000, 1000, 4)