### PR TITLE
Unify configuration and simplify spark serialization

### DIFF
--- a/docs/gettingstarted/constructing.md
+++ b/docs/gettingstarted/constructing.md
@@ -4,33 +4,36 @@ In order to construct models on the parameter servers we first need to start a m
 
 ## Connect to master
 
-Before we can spawn distributed models on the parameter server, we first need to connect to the running master node. We assume that this is running on localhost. Let's create a configuration file for our project first. Call it `glint.conf` and place it in the project's root directory. Give it the following contents:
+Before we can spawn distributed models on the parameter server, we first need to connect to the running master node. 
+This is accomplished by constructing a client object that loads a configuration file that contains all the information 
+to communicate with the master node and parameter servers. For a localhost test, the default configuration will suffice.
+Open the SBT console if you had closed it, and enter the following: 
 
-    glint.master.host = "127.0.0.1"
-    glint.master.port = 13370
-    glint.client.timeout = 30s
+    import glint.Client    
+    val client = Client()
+  
+This will construct a client object that acts as an interface to the parameter servers. We can now use this client 
+object to construct distributed matrices and vectors on the parameter server.
 
-Open the sbt console if you had closed it, and enter the following commands:
+If you need to change the default configuration (for example if your master node is not on localhost but has a 
+different hostname or IP), you can create a `glint.conf` file. See [src/main/resources/glint.conf](https://github.com/rjagerman/glint/blob/master/src/main/resources/glint.conf)
+for a comprehensive example. To load a custom configuration file, use the following:
 
     import com.typesafe.config.ConfigFactory
     import glint.Client
-
-    val client = Client(ConfigFactory.parseFile(new java.io.File("glint.conf")))
-
-This will construct a client object that acts as an interface to the parameter servers. We can now use this client object to construct distributed matrices and vectors on the parameter server.
+    val client = Client(ConfigFactory.parseFile(new java.io.File("/path/to/glint.conf")))
 
 ## Construct a matrix
 
-Now that the Client object is connected to the Master node we can try to construct a distributed matrix. Let's create a distributed matrix that stores `Double` values and has 10000 rows with 2000 columns:
+Now that the Client object is connected to the Master node we can try to construct a distributed matrix. Let's create a 
+distributed matrix that stores `Double` values and has 10000 rows with 2000 columns:
 
     val matrix = client.matrix[Double](10000, 2000)
 
-Before we can interact with this matrix we need to define an execution context and timeout for the requests. Here we use the default global execution context and a timeout of 30 seconds:
+Before we can interact with this matrix we need to define an execution context for the requests. Here we use the 
+default global execution context:
 
-    import scala.concurrent.duration._
-    import akka.util.Timeout
     implicit val ec = scala.concurrent.ExecutionContext.Implicits.global
-    implicit val timeout = new Timeout(30 seconds)
 
 To destroy the matrix and release the allocated resources on the parameter servers, run:
 

--- a/docs/gettingstarted/spark.md
+++ b/docs/gettingstarted/spark.md
@@ -36,8 +36,8 @@ And a distributed vector:
     val vector = client.vector[Double](10)
     
 The main code will use the constructed `vector` object within a spark closure such as `rdd.foreach { ... }`. There is 
-some additional boilerplate to deal with the execution context and timeouts. This is, however, a small price to pay 
-for the gained flexibility and customizability of the concurrency of your code.
+some additional boilerplate to deal with the execution context. This is, however, a small price to pay for the gained 
+flexibility and customizability of the concurrency of your code.
 
     import scala.concurrent.ExecutionContext
     rdd.foreach {

--- a/docs/gettingstarted/spark.md
+++ b/docs/gettingstarted/spark.md
@@ -1,35 +1,66 @@
 # Spark integration
 
-So far you have seen a very short introduction to programming with the Glint parameter server. At its core you will construct a client that will construct either matrices or vectors. You then use the `pull` and `push` methods on these matrices or vectors to query and update the current state of the matrix. Now how does this relate to spark?
+So far you have seen a very short introduction to programming with the Glint parameter server. At its core you will
+construct a client that will construct either matrices or vectors. You then use the `pull` and `push` methods on these
+matrices or vectors to query and update the current state of the matrix. Now how does this relate to spark?
 
-The main idea is that the `BigMatrix` and `BigVector` objects that you obtain from the client are serializable and are safe to be used within Spark closures. So let's give a quick example:
+The main idea is that the `BigMatrix` and `BigVector` objects that you obtain from the client are serializable and 
+are safe to be used within Spark closures. It should be noted that operations such as `push` and `pull` on the 
+BigMatrix and BigVector objects will need access to the implicit execution context and the implicit timeout. These 
+objects are not serializable which can cause problems when running a closure naively.
 
-    val rdd = sc.parallelize(Array(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)) // Some spark RDD
+## Example: add values of an RDD to a distributed vector
+In this example we will have an RDD that contains tuples of (Int, Double). The Int represents the key (or index) of a 
+vector and the Double represents the corresponding value. We want to add these values to a distributed vector that is 
+stored on the parameter servers. First, let's open the spark-shell and add the Glint jar dependency:
+
+    $ spark-shell --jars ./target/scala-2.10/Glint-assembly-0.1-SNAPSHOT.jar
+    
+Meanwhile, make sure the parameter servers are up and running in separate terminal windows:
+ 
+    $ sbt "run master"
+    $ sbt "run server"
+    $ sbt "run server"
+ 
+Let's construct a client (make sure to mark it as transient so the spark-shell doesn't try to serialize it):
+
+    import com.typesafe.config.ConfigFactory
+    import glint.Client
+    
+    @transient val client = Client(ConfigFactory.parseFile(new java.io.File("/path/to/your/glint.conf")))
+    
+Now, let's create our data of (key, value) pairs as an RDD:
+    
+    val rdd = sc.parallelize(Array((0, 0.0), (1, 2.0), (2, -9.0), (3, 5.5), (4, 3.14), (5, 55.5), (6, 0.01), (7, 10.0), (8, 100.0), (9, 1000.0)))
+
+And a distributed vector:
+
     val vector = client.vector[Double](10)
+    
+The main code will use the constructed `vector` object within a spark closure such as `rdd.foreach { ... }`. There is 
+some additional boilerplate to deal with the execution context and timeouts. This is, however, a small price to pay 
+for the gained flexibility and customizability of the concurrency of your code.
 
+    import akka.util.Timeout
+    import scala.concurrent.duration._
+    import scala.concurrent.ExecutionContext
+    import java.util.concurrent.Executors
     rdd.foreach {
-        case value => vector.push(Array(value), Array(12)) // Add 12 to every index of the vector
+        case (index, value) =>
+            implicit val ec = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(4))
+            implicit val timeout = new Timeout(30 seconds)
+            vector.push(Array(index), Array(value))
     }
+    
+Finally, let's verify the result by pulling the values from the parameter server:
 
-    val result = vector.pull((0L until 10).toArray)
-    result.onSuccess {
+    import scala.concurrent.ExecutionContext
+    @transient implicit val ec = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(4))
+    @transient implicit val timeout = new Timeout(30 seconds)
+    vector.pull((0L until 10).toArray).onSuccess {
         case values => println(values.mkString(", "))
     }
-    result.onComplete {
-        case _ => vector.destroy()
-    }
 
-It should be noted that operations such as `push` and `pull` on the BigMatrix and BigVector objects will need access to the implicit execution context and the implicit timeout. These objects are not serializable which can cause problems when running a closure naively. In the above example you will typically want to do something like this:
+We should observe the expected output:
 
-    rdd.foreachPartition {
-        case values => 
-          implicit val ec = ExecutionContext.Implicits.global
-          implicit val timeout = new Timeout(30 seconds)
-
-          values.foreach {
-            case value => vector.push(Array(value), Array(12))
-          }
-
-    }
-
-If your execution context and timeout are defined outside the scope of the closure, Spark will attempt to serialize them and throw an error. This also means that running within the Spark shell is currently not possible due to the shell's attempts to serialize everything. We hope to resolve this in future versions to make it easier to prototype with.
+    0.0, 2.0, -9.0, 5.5, 3.14, 55.5, 0.01, 10.0, 100.0, 1000.0

--- a/src/main/resources/glint.conf
+++ b/src/main/resources/glint.conf
@@ -25,7 +25,7 @@ glint {
     # We wish to change some of the default akka remoting configuration for the master node
     # Here we make sure lifecycle events are logged and make sure that netty tcp uses the appropriate hostname and port
     akka.remote {
-      log-remote-lifecycle-events = on
+      log-remote-lifecycle-events = off
       netty.tcp {
         hostname = ${glint.master.host}
         port = ${glint.master.port}
@@ -77,6 +77,43 @@ glint {
       hostname = ${glint.client.host}
       port = ${glint.client.port}
     }
+  }
+
+  # Configuration for pull requests
+  pull {
+
+    # Number of pull attempts before giving up and failing the request
+    maximum-attempts = 10
+
+    # Initial timeout of the pull request
+    initial-timeout = 5 seconds
+
+    # Maximum timeout
+    maximum-timeout = 5 minutes
+
+    # Exponential backoff multiplier, the timeout gets multiplied by this value every failed attempt
+    backoff-multiplier = 1.6
+
+  }
+
+  # Configuration for push requests
+  push {
+
+    # Number of push attempts before giving up and failing the request
+    maximum-attempts = 10
+
+    # Number of logic communication attempts before giving up and failing the request
+    maximum-logic-attempts = 100
+
+    # Initial timeout of the push request
+    initial-timeout = 5 seconds
+
+    # Maximum timeout
+    maximum-timeout = 5 minutes
+
+    # Exponential backoff multiplier, the timeout gets multiplied by this value every failed attempt
+    backoff-multiplier = 1.6
+
   }
 
   # Default configuration setting

--- a/src/main/scala/glint/Client.scala
+++ b/src/main/scala/glint/Client.scala
@@ -250,6 +250,15 @@ class Client(val config: Config,
 object Client {
 
   /**
+    * Constructs a client with the default configuration
+    *
+    * @return The client
+    */
+  def apply(): Client = {
+    this(ConfigFactory.empty())
+  }
+
+  /**
     * Constructs a client
     *
     * @param config The configuration
@@ -258,7 +267,7 @@ object Client {
   def apply(config: Config): Client = {
     val default = ConfigFactory.parseResourcesAnySyntax("glint")
     val conf = config.withFallback(default).resolve()
-    Await.result(start(conf), config.getDuration("glint.client.timeout", TimeUnit.MILLISECONDS) milliseconds)
+    Await.result(start(conf), conf.getDuration("glint.client.timeout", TimeUnit.MILLISECONDS) milliseconds)
   }
 
   /**

--- a/src/main/scala/glint/iterators/ColumnIterator.scala
+++ b/src/main/scala/glint/iterators/ColumnIterator.scala
@@ -11,10 +11,9 @@ import scala.concurrent.{ExecutionContext, Future}
   *
   * @param matrix The matrix
   * @param ec The implicit execution context in which to execute requests
-  * @param timeout The timeout
   * @tparam V The type of values
   */
-class ColumnIterator[V](val matrix: BigMatrix[V])(implicit ec: ExecutionContext, timeout: Timeout)
+class ColumnIterator[V](val matrix: BigMatrix[V])(implicit ec: ExecutionContext)
   extends PipelineIterator[Array[V]] {
 
   total = if (matrix.cols == 0 || matrix.rows == 0) {

--- a/src/main/scala/glint/iterators/RowBlockIterator.scala
+++ b/src/main/scala/glint/iterators/RowBlockIterator.scala
@@ -12,10 +12,9 @@ import scala.concurrent.{ExecutionContext, Future}
   * @param matrix The big matrix to iterate over
   * @param blockSize How many rows to retrieve per iteration
   * @param ec The implicit execution context in which to execute requests
-  * @param timeout The timeout on requests before they are considered lost
   */
 class RowBlockIterator[V](val matrix: BigMatrix[V],
-                          val blockSize: Int)(implicit ec: ExecutionContext, timeout: Timeout)
+                          val blockSize: Int)(implicit ec: ExecutionContext)
   extends PipelineIterator[Array[Vector[V]]] {
 
   if (matrix.cols == 0 || matrix.rows == 0) {

--- a/src/main/scala/glint/iterators/RowIterator.scala
+++ b/src/main/scala/glint/iterators/RowIterator.scala
@@ -11,8 +11,9 @@ import scala.concurrent.ExecutionContext
   *
   * @param matrix The underlying matrix to iterate over
   * @param blockSize The number of rows to pull per request (default: 100)
+  * @param ec The implicit execution context in which to execute requests
   */
-class RowIterator[V](matrix: BigMatrix[V], blockSize: Int = 100)(implicit val ec: ExecutionContext, timeout: Timeout)
+class RowIterator[V](matrix: BigMatrix[V], blockSize: Int = 100)(implicit val ec: ExecutionContext)
   extends Iterator[Vector[V]] {
 
   // Row progress

--- a/src/main/scala/glint/models/client/BigMatrix.scala
+++ b/src/main/scala/glint/models/client/BigMatrix.scala
@@ -34,22 +34,20 @@ trait BigMatrix[V] extends Serializable {
     * Pulls a set of rows
     *
     * @param rows The indices of the rows
-    * @param timeout The timeout for this request
     * @param ec The implicit execution context in which to execute the request
     * @return A future containing the vectors representing the rows
     */
-  def pull(rows: Array[Long])(implicit timeout: Timeout, ec: ExecutionContext): Future[Array[Vector[V]]]
+  def pull(rows: Array[Long])(implicit ec: ExecutionContext): Future[Array[Vector[V]]]
 
   /**
     * Pulls a set of elements
     *
     * @param rows The indices of the rows
     * @param cols The corresponding indices of the columns
-    * @param timeout The timeout for this request
     * @param ec The implicit execution context in which to execute the request
     * @return A future containing the values of the elements at given rows, columns
     */
-  def pull(rows: Array[Long], cols: Array[Int])(implicit timeout: Timeout, ec: ExecutionContext): Future[Array[V]]
+  def pull(rows: Array[Long], cols: Array[Int])(implicit ec: ExecutionContext): Future[Array[V]]
 
   /**
     * Pushes a set of values
@@ -57,20 +55,18 @@ trait BigMatrix[V] extends Serializable {
     * @param rows The indices of the rows
     * @param cols The indices of the columns
     * @param values The values to update
-    * @param timeout The timeout for this request
     * @param ec The implicit execution context in which to execute the request
     * @return A future containing either the success or failure of the operation
     */
-  def push(rows: Array[Long], cols: Array[Int], values: Array[V])(implicit timeout: Timeout, ec: ExecutionContext): Future[Boolean]
+  def push(rows: Array[Long], cols: Array[Int], values: Array[V])(implicit ec: ExecutionContext): Future[Boolean]
 
 
   /**
     * Destroys the big matrix and its resources on the parameter server
     *
-    * @param timeout The timeout for this request
     * @param ec The implicit execution context in which to execute the request
     * @return A future whether the matrix was successfully destroyed
     */
-  def destroy()(implicit timeout: Timeout, ec: ExecutionContext): Future[Boolean]
+  def destroy()(implicit ec: ExecutionContext): Future[Boolean]
 
 }

--- a/src/main/scala/glint/models/client/BigVector.scala
+++ b/src/main/scala/glint/models/client/BigVector.scala
@@ -24,30 +24,27 @@ trait BigVector[V] extends Serializable {
     * Pulls a set of elements
     *
     * @param keys The indices of the elements
-    * @param timeout The timeout for this request
     * @param ec The implicit execution context in which to execute the request
     * @return A future containing the values of the elements at given rows, columns
     */
-  def pull(keys: Array[Long])(implicit timeout: Timeout, ec: ExecutionContext): Future[Array[V]]
+  def pull(keys: Array[Long])(implicit ec: ExecutionContext): Future[Array[V]]
 
   /**
     * Pushes a set of values
     *
     * @param keys The indices of the rows
     * @param values The values to update
-    * @param timeout The timeout for this request
     * @param ec The implicit execution context in which to execute the request
     * @return A future containing either the success or failure of the operation
     */
-  def push(keys: Array[Long], values: Array[V])(implicit timeout: Timeout, ec: ExecutionContext): Future[Boolean]
+  def push(keys: Array[Long], values: Array[V])(implicit ec: ExecutionContext): Future[Boolean]
 
   /**
     * Destroys the big vector and its resources on the parameter server
     *
-    * @param timeout The timeout for this request
     * @param ec The implicit execution context in which to execute the request
     * @return A future whether the vector was successfully destroyed
     */
-  def destroy()(implicit timeout: Timeout, ec: ExecutionContext): Future[Boolean]
+  def destroy()(implicit ec: ExecutionContext): Future[Boolean]
 
 }

--- a/src/main/scala/glint/models/client/buffered/BufferedBigMatrix.scala
+++ b/src/main/scala/glint/models/client/buffered/BufferedBigMatrix.scala
@@ -37,22 +37,20 @@ class BufferedBigMatrix[@specialized V: ClassTag](underlying: BigMatrix[V], buff
     * Pulls a set of rows using the underlying BigMatrix implementation
     *
     * @param rows The indices of the rows
-    * @param timeout The timeout for this request
     * @param ec The implicit execution context in which to execute the request
     * @return A future containing the vectors representing the rows
     */
-  override def pull(rows: Array[Long])(implicit timeout: Timeout, ec: ExecutionContext): Future[Array[Vector[V]]] = {
+  override def pull(rows: Array[Long])(implicit ec: ExecutionContext): Future[Array[Vector[V]]] = {
     underlying.pull(rows)
   }
 
   /**
     * Destroys the underlying big matrix and its resources on the parameter server
     *
-    * @param timeout The timeout for this request
     * @param ec The implicit execution context in which to execute the request
     * @return A future whether the matrix was successfully destroyed
     */
-  override def destroy()(implicit timeout: Timeout, ec: ExecutionContext): Future[Boolean] = underlying.destroy()
+  override def destroy()(implicit ec: ExecutionContext): Future[Boolean] = underlying.destroy()
 
   /**
     * Pushes a set of values using the underlying BigMatrix implementation
@@ -60,13 +58,12 @@ class BufferedBigMatrix[@specialized V: ClassTag](underlying: BigMatrix[V], buff
     * @param rows The indices of the rows
     * @param cols The indices of the columns
     * @param values The values to update
-    * @param timeout The timeout for this request
     * @param ec The implicit execution context in which to execute the request
     * @return A future containing either the success or failure of the operation
     */
   override def push(rows: Array[Long],
                     cols: Array[Int],
-                    values: Array[V])(implicit timeout: Timeout, ec: ExecutionContext): Future[Boolean] = {
+                    values: Array[V])(implicit ec: ExecutionContext): Future[Boolean] = {
     underlying.push(rows, cols, values)
   }
 
@@ -93,11 +90,10 @@ class BufferedBigMatrix[@specialized V: ClassTag](underlying: BigMatrix[V], buff
   /**
     * Flushes the buffer to the parameter server.
     *
-    * @param timeout The timeout for this request
     * @param ec The implicit execution context in which to execute the request
     * @return A future containing the success or failure of the operation
     */
-  def flush()(implicit timeout: Timeout, ec: ExecutionContext): Future[Boolean] = {
+  def flush()(implicit ec: ExecutionContext): Future[Boolean] = {
     if (bufferIndex == 0) {
       Future {
         true
@@ -131,12 +127,11 @@ class BufferedBigMatrix[@specialized V: ClassTag](underlying: BigMatrix[V], buff
     *
     * @param rows The indices of the rows
     * @param cols The corresponding indices of the columns
-    * @param timeout The timeout for this request
     * @param ec The implicit execution context in which to execute the request
     * @return A future containing the values of the elements at given rows, columns
     */
   override def pull(rows: Array[Long],
-                    cols: Array[Int])(implicit timeout: Timeout, ec: ExecutionContext): Future[Array[V]] = {
+                    cols: Array[Int])(implicit ec: ExecutionContext): Future[Array[V]] = {
     underlying.pull(rows, cols)
   }
 }

--- a/src/main/scala/glint/models/client/granular/GranularBigMatrix.scala
+++ b/src/main/scala/glint/models/client/granular/GranularBigMatrix.scala
@@ -32,11 +32,10 @@ class GranularBigMatrix[V: ClassTag](underlying: BigMatrix[V],
     * Pulls a set of rows while attempting to keep individual network messages smaller than `maximumMessageSize`
     *
     * @param rows The indices of the rows
-    * @param timeout The timeout for this request
     * @param ec The implicit execution context in which to execute the request
     * @return A future containing the vectors representing the rows
     */
-  override def pull(rows: Array[Long])(implicit timeout: Timeout, ec: ExecutionContext): Future[Array[Vector[V]]] = {
+  override def pull(rows: Array[Long])(implicit ec: ExecutionContext): Future[Array[Vector[V]]] = {
     if (rows.length * cols <= maximumMessageSize) {
       underlying.pull(rows)
     } else {
@@ -63,11 +62,10 @@ class GranularBigMatrix[V: ClassTag](underlying: BigMatrix[V],
   /**
     * Destroys the big matrix and its resources on the parameter server
     *
-    * @param timeout The timeout for this request
     * @param ec The implicit execution context in which to execute the request
     * @return A future whether the matrix was successfully destroyed
     */
-  override def destroy()(implicit timeout: Timeout, ec: ExecutionContext): Future[Boolean] = underlying.destroy()
+  override def destroy()(implicit ec: ExecutionContext): Future[Boolean] = underlying.destroy()
 
   /**
     * Pushes a set of values while keeping individual network messages smaller than `maximumMessageSize`
@@ -75,13 +73,12 @@ class GranularBigMatrix[V: ClassTag](underlying: BigMatrix[V],
     * @param rows The indices of the rows
     * @param cols The indices of the columns
     * @param values The values to update
-    * @param timeout The timeout for this request
     * @param ec The implicit execution context in which to execute the request
     * @return A future containing either the success or failure of the operation
     */
   override def push(rows: Array[Long],
                     cols: Array[Int],
-                    values: Array[V])(implicit timeout: Timeout, ec: ExecutionContext): Future[Boolean] = {
+                    values: Array[V])(implicit ec: ExecutionContext): Future[Boolean] = {
     if (rows.length <= maximumMessageSize) {
       underlying.push(rows, cols, values)
     } else {
@@ -102,12 +99,11 @@ class GranularBigMatrix[V: ClassTag](underlying: BigMatrix[V],
     *
     * @param rows The indices of the rows
     * @param cols The corresponding indices of the columns
-    * @param timeout The timeout for this request
     * @param ec The implicit execution context in which to execute the request
     * @return A future containing the values of the elements at given rows, columns
     */
   override def pull(rows: Array[Long],
-                    cols: Array[Int])(implicit timeout: Timeout, ec: ExecutionContext): Future[Array[V]] = {
+                    cols: Array[Int])(implicit ec: ExecutionContext): Future[Array[V]] = {
     if (rows.length <= maximumMessageSize) {
       underlying.pull(rows, cols)
     } else {

--- a/src/main/scala/glint/models/client/retry/RetryBigMatrix.scala
+++ b/src/main/scala/glint/models/client/retry/RetryBigMatrix.scala
@@ -22,11 +22,10 @@ class RetryBigMatrix[@specialized V](underlying: BigMatrix[V], val attempts: Int
     * Pulls a set of rows
     *
     * @param rows The indices of the rows
-    * @param timeout The timeout for this request
     * @param ec The implicit execution context in which to execute the request
     * @return A future containing the vectors representing the rows
     */
-  override def pull(rows: Array[Long])(implicit timeout: Timeout, ec: ExecutionContext): Future[Array[Vector[V]]] = {
+  override def pull(rows: Array[Long])(implicit ec: ExecutionContext): Future[Array[Vector[V]]] = {
     implicit val success = Success.always
     retry.Directly(attempts) { () =>
       underlying.pull(rows)
@@ -36,11 +35,10 @@ class RetryBigMatrix[@specialized V](underlying: BigMatrix[V], val attempts: Int
   /**
     * Destroys the big matrix and its resources on the parameter server
     *
-    * @param timeout The timeout for this request
     * @param ec The implicit execution context in which to execute the request
     * @return A future whether the matrix was successfully destroyed
     */
-  override def destroy()(implicit timeout: Timeout, ec: ExecutionContext): Future[Boolean] = {
+  override def destroy()(implicit ec: ExecutionContext): Future[Boolean] = {
     implicit val success = Success.apply[Boolean](identity)
     retry.Directly(attempts) { () =>
       underlying.destroy()
@@ -53,13 +51,12 @@ class RetryBigMatrix[@specialized V](underlying: BigMatrix[V], val attempts: Int
     * @param rows The indices of the rows
     * @param cols The indices of the columns
     * @param values The values to update
-    * @param timeout The timeout for this request
     * @param ec The implicit execution context in which to execute the request
     * @return A future containing either the success or failure of the operation
     */
   override def push(rows: Array[Long],
                     cols: Array[Int],
-                    values: Array[V])(implicit timeout: Timeout, ec: ExecutionContext): Future[Boolean] = {
+                    values: Array[V])(implicit ec: ExecutionContext): Future[Boolean] = {
     implicit val success = Success[Boolean](identity)
     retry.Directly(attempts) { () =>
       underlying.push(rows, cols, values)
@@ -71,12 +68,11 @@ class RetryBigMatrix[@specialized V](underlying: BigMatrix[V], val attempts: Int
     *
     * @param rows The indices of the rows
     * @param cols The corresponding indices of the columns
-    * @param timeout The timeout for this request
     * @param ec The implicit execution context in which to execute the request
     * @return A future containing the values of the elements at given rows, columns
     */
   override def pull(rows: Array[Long],
-                    cols: Array[Int])(implicit timeout: Timeout, ec: ExecutionContext): Future[Array[V]] = {
+                    cols: Array[Int])(implicit ec: ExecutionContext): Future[Array[V]] = {
     implicit val success = Success.always
     retry.Directly(attempts) { () =>
       underlying.pull(rows, cols)

--- a/src/main/scala/glint/models/client/retry/RetryBigVector.scala
+++ b/src/main/scala/glint/models/client/retry/RetryBigVector.scala
@@ -19,11 +19,10 @@ class RetryBigVector[@specialized V](underlying: BigVector[V], val attempts: Int
   /**
     * Destroys the big Vector and its resources on the parameter server
     *
-    * @param timeout The timeout for this request
     * @param ec The implicit execution context in which to execute the request
     * @return A future whether the Vector was successfully destroyed
     */
-  override def destroy()(implicit timeout: Timeout, ec: ExecutionContext): Future[Boolean] = {
+  override def destroy()(implicit ec: ExecutionContext): Future[Boolean] = {
     implicit val success = Success.apply[Boolean](identity)
     retry.Directly(attempts) { () =>
       underlying.destroy()
@@ -35,12 +34,11 @@ class RetryBigVector[@specialized V](underlying: BigVector[V], val attempts: Int
     *
     * @param keys The indices of the keys
     * @param values The values to update
-    * @param timeout The timeout for this request
     * @param ec The implicit execution context in which to execute the request
     * @return A future containing either the success or failure of the operation
     */
   override def push(keys: Array[Long],
-                    values: Array[V])(implicit timeout: Timeout, ec: ExecutionContext): Future[Boolean] = {
+                    values: Array[V])(implicit ec: ExecutionContext): Future[Boolean] = {
     implicit val success = Success[Boolean](identity)
     retry.Directly(attempts) { () =>
       underlying.push(keys, values)
@@ -51,11 +49,10 @@ class RetryBigVector[@specialized V](underlying: BigVector[V], val attempts: Int
     * Pulls a set of elements
     *
     * @param keys The indices of the keys
-    * @param timeout The timeout for this request
     * @param ec The implicit execution context in which to execute the request
     * @return A future containing the values of the elements at given rows, columns
     */
-  override def pull(keys: Array[Long])(implicit timeout: Timeout, ec: ExecutionContext): Future[Array[V]] = {
+  override def pull(keys: Array[Long])(implicit ec: ExecutionContext): Future[Array[V]] = {
     implicit val success = Success.always
     retry.Directly(attempts) { () =>
       underlying.pull(keys)

--- a/src/test/scala/glint/SystemTest.scala
+++ b/src/test/scala/glint/SystemTest.scala
@@ -14,7 +14,8 @@ import scala.concurrent.duration._
   */
 trait SystemTest extends ScalaFutures {
 
-  val testConfig = ConfigFactory.parseString(
+  val testConfig = ConfigFactory.load("glint")
+  /*val testConfig = ConfigFactory.parseString(
     """
       |glint {
       |  master {
@@ -50,6 +51,19 @@ trait SystemTest extends ScalaFutures {
       |      hostname = ${glint.client.host}
       |      port = ${glint.client.port}
       |    }
+      |  }
+      |  pull {
+      |    maximum-attempts = 10
+      |    initial-timeout = 5 seconds
+      |    maximum-timeout = 5 minutes
+      |    backoff-multiplier = 1.6
+      |  }
+      |  push {
+      |    maximum-attempts = 10
+      |    maximum-logic-attempts = 100
+      |    initial-timeout = 5 seconds
+      |    maximum-timeout = 5 minutes
+      |    backoff-multiplier = 1.6
       |  }
       |  default {
       |    akka {
@@ -96,11 +110,9 @@ trait SystemTest extends ScalaFutures {
       |  }
       |}
     """.stripMargin
-  ).resolve()
+  ).resolve()*/
 
   implicit val ec = ExecutionContext.Implicits.global
-
-  implicit val timeout = Timeout(10 seconds)
 
   implicit val defaultPatience =
     PatienceConfig(timeout = Span(10, Seconds), interval = Span(50, Millis))

--- a/src/test/scala/glint/mocking/MockBigMatrix.scala
+++ b/src/test/scala/glint/mocking/MockBigMatrix.scala
@@ -47,7 +47,7 @@ class MockBigMatrix[V: ClassTag](nrOfRows: Int, val cols: Int, default: V,
     * @param ec The implicit execution context in which to execute the request
     * @return A future containing the vectors representing the rows
     */
-  override def pull(rows: Array[Long])(implicit timeout: Timeout, ec: ExecutionContext): Future[Array[Vector[V]]] = {
+  override def pull(rows: Array[Long])(implicit ec: ExecutionContext): Future[Array[Vector[V]]] = {
     if (failNextPull || destroyed) {
       failNextPulls -= 1
       fail()
@@ -71,7 +71,7 @@ class MockBigMatrix[V: ClassTag](nrOfRows: Int, val cols: Int, default: V,
     * @param ec The implicit execution context in which to execute the request
     * @return A future whether the matrix was successfully destroyed
     */
-  override def destroy()(implicit timeout: Timeout, ec: ExecutionContext): Future[Boolean] = {
+  override def destroy()(implicit ec: ExecutionContext): Future[Boolean] = {
     destroyed = true
     Future { true }
   }
@@ -88,7 +88,7 @@ class MockBigMatrix[V: ClassTag](nrOfRows: Int, val cols: Int, default: V,
     */
   override def push(rows: Array[Long],
                     cols: Array[Int],
-                    values: Array[V])(implicit timeout: Timeout, ec: ExecutionContext): Future[Boolean] = {
+                    values: Array[V])(implicit ec: ExecutionContext): Future[Boolean] = {
     if (failNextPush || destroyed) {
       failNextPushes -= 1
       fail()
@@ -116,7 +116,7 @@ class MockBigMatrix[V: ClassTag](nrOfRows: Int, val cols: Int, default: V,
     * @return A future containing the values of the elements at given rows, columns
     */
   override def pull(rows: Array[Long],
-                    cols: Array[Int])(implicit timeout: Timeout, ec: ExecutionContext): Future[Array[V]] = {
+                    cols: Array[Int])(implicit ec: ExecutionContext): Future[Array[V]] = {
     if (failNextPull || destroyed) {
       failNextPulls -= 1
       fail()

--- a/src/test/scala/glint/mocking/MockBigVector.scala
+++ b/src/test/scala/glint/mocking/MockBigVector.scala
@@ -43,7 +43,7 @@ class MockBigVector[V: ClassTag](keys: Int, cols: Int, default: V, aggregate: (V
     * @param ec The implicit execution context in which to execute the request
     * @return A future whether the Vector was successfully destroyed
     */
-  override def destroy()(implicit timeout: Timeout, ec: ExecutionContext): Future[Boolean] = {
+  override def destroy()(implicit ec: ExecutionContext): Future[Boolean] = {
     destroyed = true
     Future { true }
   }
@@ -58,7 +58,7 @@ class MockBigVector[V: ClassTag](keys: Int, cols: Int, default: V, aggregate: (V
     * @return A future containing either the success or failure of the operation
     */
   override def push(keys: Array[Long],
-                    values: Array[V])(implicit timeout: Timeout, ec: ExecutionContext): Future[Boolean] = {
+                    values: Array[V])(implicit ec: ExecutionContext): Future[Boolean] = {
     if (failNextPush || destroyed) {
       failNextPushes -= 1
       fail()
@@ -82,7 +82,7 @@ class MockBigVector[V: ClassTag](keys: Int, cols: Int, default: V, aggregate: (V
     * @param ec The implicit execution context in which to execute the request
     * @return A future containing the values of the elements at given rows, columns
     */
-  override def pull(keys: Array[Long])(implicit timeout: Timeout, ec: ExecutionContext): Future[Array[V]] = {
+  override def pull(keys: Array[Long])(implicit ec: ExecutionContext): Future[Array[V]] = {
     if (failNextPull || destroyed) {
       failNextPulls -= 1
       fail()


### PR DESCRIPTION
This pull requests unifies most of the parameters into a single configuration file and simplifies serialization in spark by removing the (now unnecessary) implicit timeout parameters from the pull/push function calls.