### PR TITLE
Upgrade scala and akka versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: scala
 scala:
    - 2.10.6
    - 2.11.8
-
+jdk:
+   - oraclejdk8
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 scala:
    - 2.10.6
-   - 2.11.7
+   - 2.11.8
 
 branches:
   only:

--- a/build.sbt
+++ b/build.sbt
@@ -6,22 +6,27 @@ organization := "ch.ethz.inf.da"
 
 scalaVersion := "2.10.6"
 
-crossScalaVersions := Seq("2.10.6", "2.11.7")
+crossScalaVersions := Seq("2.10.6", "2.11.8")
 
 fork in Test := true
 
 // Akka
 
-libraryDependencies += "com.typesafe.akka" %% "akka-actor" % "2.3.14"
-
-libraryDependencies += "com.typesafe.akka" %% "akka-remote" % "2.3.14"
-
 libraryDependencies <+= scalaVersion {
-  case x if x.startsWith("2.10") => "com.typesafe.akka" % "akka-stream-experimental_2.10" % "2.0.2"
-  case x if x.startsWith("2.11") => "com.typesafe.akka" % "akka-stream-experimental_2.11" % "2.0.2"
+  case x if x.startsWith("2.10") => "com.typesafe.akka" %% "akka-actor" % "2.3.15"
+  case x if x.startsWith("2.11") => "com.typesafe.akka" %% "akka-actor" % "2.4.7"
 }
 
-libraryDependencies += "com.typesafe.akka" %% "akka-testkit" % "2.3.14"
+libraryDependencies <+= scalaVersion {
+  case x if x.startsWith("2.10") => "com.typesafe.akka" %% "akka-remote" % "2.3.15"
+  case x if x.startsWith("2.11") => "com.typesafe.akka" %% "akka-remote" % "2.4.7"
+}
+
+libraryDependencies <+= scalaVersion {
+  case x if x.startsWith("2.10") => "com.typesafe.akka" %% "akka-testkit" % "2.3.15"
+  case x if x.startsWith("2.11") => "com.typesafe.akka" %% "akka-testkit" % "2.4.7"
+}
+
 
 // Retry
 

--- a/src/test/scala/glint/SystemTest.scala
+++ b/src/test/scala/glint/SystemTest.scala
@@ -115,7 +115,7 @@ trait SystemTest extends ScalaFutures {
   implicit val ec = ExecutionContext.Implicits.global
 
   implicit val defaultPatience =
-    PatienceConfig(timeout = Span(10, Seconds), interval = Span(50, Millis))
+    PatienceConfig(timeout = Span(60, Seconds), interval = Span(500, Millis))
 
   /**
     * Fixture that starts a master when running test code and cleans up where necessary

--- a/src/test/scala/glint/serialization/SerializationBenchmark.scala
+++ b/src/test/scala/glint/serialization/SerializationBenchmark.scala
@@ -1,6 +1,7 @@
 package glint.serialization
 
-import akka.serialization.JavaSerializer
+import akka.actor.ActorSystem
+import akka.serialization.{JavaSerializer, SerializationExtension}
 import glint.SystemTest
 import glint.messages.server.request.PullMatrix
 import glint.messages.server.response.ResponseLong
@@ -20,7 +21,7 @@ object SerializationBenchmark extends Bench.OfflineReport with SystemTest {
   // Construct serializers
   val requestSerializer = new RequestSerializer()
   val responseSerializer = new ResponseSerializer()
-  val defaultJavaSerializer = new JavaSerializer(JavaSerializer.currentSystem.value)
+  val defaultJavaSerializer = SerializationExtension(ActorSystem()).findSerializerFor("")
 
   // Defines number of iterations to test (test size)
   val sizes = Gen.range("size")(1000, 9000, 2000)


### PR DESCRIPTION
This will update the available scala versions to 2.10.6 and 2.11.8 and also update Akka to the newest version 2.4.7 (for scala 2.11.8) and 2.3.15 (for scala 2.10.6).